### PR TITLE
[feature/79] Don't hardcode font families

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-react-hooks": "4.2.0"
   },
   "engines": {
-    "node": "14"
+    "node": ">=14"
   },
   "browserslist": {
     "production": [

--- a/src/home/cards/a-card/body.jsx
+++ b/src/home/cards/a-card/body.jsx
@@ -3,7 +3,7 @@ import { makeStyles, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({
   body: {
-    fontFamily: 'IBM Plex Sans',
+    fontFamily: theme.typography.fontFamily,
     fontStyle: 'normal',
     fontWeight: 'normal',
     fontSize: 16,

--- a/src/home/cards/a-card/call-button.jsx
+++ b/src/home/cards/a-card/call-button.jsx
@@ -4,7 +4,7 @@ import ArrowForwardIcon from '@material-ui/icons/ArrowForward'
 
 const useStyles = makeStyles(theme => ({
   button: {
-    fontFamily: 'IBM Plex Sans',
+    fontFamily: theme.typography.fontFamily,
     fontStyle: 'normal',
     fontWeight: 'bold',
     fontSize: '16px',

--- a/src/home/cards/a-card/title.jsx
+++ b/src/home/cards/a-card/title.jsx
@@ -3,7 +3,7 @@ import { makeStyles, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles(theme => ({
   title: {
-    fontFamily: 'IBM Plex Sans',
+    fontFamily: theme.typography.fontFamily,
     fontStyle: 'normal',
     fontWeight: 'bold',
     fontSize: '1.4em',

--- a/src/layout/common/link.jsx
+++ b/src/layout/common/link.jsx
@@ -2,8 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import * as Material from '@material-ui/core'
 
-const useStyles = Material.makeStyles(() => ({
+const useStyles = Material.makeStyles((theme) => ({
   root: {
+    fontFamily: theme.typography.fontFamily,
     fontWeight: '700',
     color: 'gray',
     cursor: 'pointer',

--- a/src/layout/common/link.jsx
+++ b/src/layout/common/link.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import * as Material from '@material-ui/core'
 
-const useStyles = Material.makeStyles((theme) => ({
+const useStyles = Material.makeStyles(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontWeight: '700',


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
Randomly looking on the project, saw that the navbar's fonts were a bit off. While fixing it thought that would be great not to hardcode the font everywhere since there is already available in the theme config.

Before:
<img width="661" alt="Screenshot 2021-08-06 at 12 10 59 pm" src="https://user-images.githubusercontent.com/2974519/128502010-ab6f0d83-60d4-4e93-866a-00038efc3d31.png">

After:

<img width="604" alt="Screenshot 2021-08-06 at 12 11 39 pm" src="https://user-images.githubusercontent.com/2974519/128502072-e20631ce-e3f1-450c-b80c-24d7b3fd63f3.png">


<!-- Please mention the main changes this PR brings. -->

Just went on the website.

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

## Related

- #79 
