### PR TITLE
155: Fix lessons filter UI

### DIFF
--- a/src/admin/lessons/filters/category.jsx
+++ b/src/admin/lessons/filters/category.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Core } from 'core'
-import * as Material from '@mui/material'
+import { Grid, Box } from '@mui/material'
 import { useStyles } from 'admin/lessons/filters/hooks/use-styles'
 
 const OPTIONS = Object.freeze([
@@ -8,8 +8,10 @@ const OPTIONS = Object.freeze([
   { value: 'two', label: 'Two' },
 ])
 
-export const Category = () => <Material.Grid item xs={12} md={4}>
-  <Material.Box pr={3} className={useStyles().box}>
-    <Core.Select title={'Filtrează după categorie'} options={OPTIONS} />
-  </Material.Box>
-</Material.Grid>
+export const Category = () => (
+  <Grid item xs={12} md={4}>
+    <Box className={useStyles().box}>
+      <Core.Select title={'Filtrează după categorie'} options={OPTIONS} />
+    </Box>
+  </Grid>
+);

--- a/src/admin/lessons/filters/hooks/use-styles.js
+++ b/src/admin/lessons/filters/hooks/use-styles.js
@@ -1,3 +1,9 @@
 import { makeStyles } from '@mui/styles'
 
-export const useStyles = makeStyles(theme => ({ box: { [theme.breakpoints.down('sm')]: { paddingRight: 0 } } }))
+export const useStyles = makeStyles((theme) => ({
+  box: {
+    [theme.breakpoints.down('md')]: {
+      paddingTop: '20px'
+    }
+  } 
+}));

--- a/src/admin/lessons/filters/index.jsx
+++ b/src/admin/lessons/filters/index.jsx
@@ -1,13 +1,15 @@
 import React from 'react'
-import * as Material from '@mui/material'
+import { Grid, Box } from '@mui/material'
 import { Search } from 'admin/lessons/filters/search'
 import { Status } from 'admin/lessons/filters/status'
 import { Category } from 'admin/lessons/filters/category'
 
-export const Filters = () => <Material.Box py={3} width={1}>
-  <Material.Grid container>
-    <Category />
-    <Status />
-    <Search />
-  </Material.Grid>
-</Material.Box>
+export const Filters = () => (
+  <Box mt={5} mb={3} width={1}>
+    <Grid container columnSpacing={3} rowSpacing={2}>
+      <Category />
+      <Status />
+      <Search />
+    </Grid>
+  </Box>
+);

--- a/src/admin/lessons/filters/status.jsx
+++ b/src/admin/lessons/filters/status.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Core } from 'core'
-import * as Material from '@mui/material'
+import { Box, Grid } from '@mui/material'
 import { useStyles } from 'admin/lessons/filters/hooks/use-styles'
 
 const OPTIONS = Object.freeze([
@@ -8,8 +8,10 @@ const OPTIONS = Object.freeze([
   { value: 'two', label: 'Two' },
 ])
 
-export const Status = () => <Material.Grid item xs={12} md={4}>
-  <Material.Box pr={3} className={useStyles().box}>
-    <Core.Select title={'Filtrează după status'} options={OPTIONS} />
-  </Material.Box>
-</Material.Grid>
+export const Status = () => (
+  <Grid item xs={12} md={4}>
+    <Box className={useStyles().box}>
+      <Core.Select title={'Filtrează după status'} options={OPTIONS} />
+    </Box>
+  </Grid>
+);

--- a/src/core/select/control.jsx
+++ b/src/core/select/control.jsx
@@ -1,11 +1,24 @@
 import React from 'react'
-import * as Material from '@mui/material'
+import { makeStyles } from '@mui/styles';
+import { Select, MenuItem as Option} from '@mui/material'
 import { useContext } from 'core/select/context'
 
-const Option = Material.MenuItem
+const useSelectStyles = makeStyles(() => ({
+  root: {
+    backgroundColor: 'white',
+  },
+}));
 
-export const Control = () => <Material.Select fullWidth value={useContext().value} onChange={useContext().handleChange}>
-  {
-    useContext().options.map((option, index) => <Option key={index} value={option.value}>{option.label}</Option>)
-  }
-</Material.Select>
+export const Control = () => {
+  const { handleChange, options, value } = useContext();
+
+  return (
+    <Select fullWidth classes={useSelectStyles()} value={value} onChange={handleChange}>
+      {options.map((option, index) => (
+        <Option key={`select-option-${index}-${option.value}`} value={option.value}>
+          {option.label}
+        </Option>
+      ))}
+    </Select>
+  );
+}

--- a/src/core/select/index.jsx
+++ b/src/core/select/index.jsx
@@ -1,13 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { makeStyles } from '@mui/styles'
+import { InputLabel } from '@mui/material'
 import { Layout } from 'core/select/layout'
 import { Control } from 'core/select/control'
-import * as Material from '@mui/material'
 
-export const Select = ({ title, options }) => <Layout options={options}>
-  <Material.InputLabel>{title}</Material.InputLabel>
-  <Control />
-</Layout>
+const useLabelStyles = makeStyles(() => ({
+  root: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    transform: 'translate(0, -100%)',
+    fontSize: '14px',
+  },
+}));
+
+export const Select = ({ title, options }) => (
+  <Layout options={options}>
+    <InputLabel classes={useLabelStyles()}>{title}</InputLabel>
+    <Control />
+  </Layout>
+);
 
 Select.propTypes = {
   title: PropTypes.string.isRequired,

--- a/src/core/select/layout.jsx
+++ b/src/core/select/layout.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import * as Material from '@mui/material'
+import { FormControl } from '@mui/material'
 import { Context, useValue } from 'core/select/context'
 
 export const Layout = ({ children, options }) => <Context.Provider value={useValue({ options })}>
-  <Material.FormControl fullWidth>
+  <FormControl fullWidth>
     {children}
-  </Material.FormControl>
+  </FormControl>
 </Context.Provider>
 
 Layout.propTypes = {


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #155  

Fixes issues on page `/admin/lessons`

- Fix filters styles on desktop/mobile where the label was hover the select 
- Fix filters styles on mobile where the first and second select had an extra right space 

### How has it been tested?

![image](https://user-images.githubusercontent.com/15066801/170826842-98728715-5f00-41f5-b7bb-a5b3120deeee.png)

![image](https://user-images.githubusercontent.com/15066801/170826821-b8fbcaf6-8f90-4061-bb3a-9394a1a3755a.png)
